### PR TITLE
Include missing typo in OCPClient

### DIFF
--- a/src/test/groovy/org/ods/e2e/openshift/client/OpenShiftClient.groovy
+++ b/src/test/groovy/org/ods/e2e/openshift/client/OpenShiftClient.groovy
@@ -97,10 +97,10 @@ class OpenShiftClient {
     }
 
     def waitForDeployment(String name, Integer lastVersion = 0) {
-        return waitForDeployment([name], [lastVersion])
+        return waitForDeployments([name], [lastVersion])
     }
 
-    def waitForDeployment(ArrayList<String> names, ArrayList<Integer> lastVersions) {
+    def waitForDeployments(ArrayList<String> names, ArrayList<Integer> lastVersions) {
         def name = names.join('|')
         def listener = new IOpenShiftWatchListener.OpenShiftWatchListenerAdapter() {
             private CountDownLatch latch = new CountDownLatch(names.size())


### PR DESCRIPTION
Just to characters to call the right methods