### PR TITLE
Ignore cookies

### DIFF
--- a/src/test/groovy/org/ods/e2e/util/UnirestWrapper.groovy
+++ b/src/test/groovy/org/ods/e2e/util/UnirestWrapper.groovy
@@ -3,6 +3,11 @@ package org.ods.e2e.util
 import kong.unirest.GetRequest
 import kong.unirest.HttpRequestWithBody
 import kong.unirest.Unirest
+import org.apache.http.client.config.CookieSpecs
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.client.HttpClients
+
+import java.net.http.HttpClient
 
 class UnirestWrapper extends Unirest {
     def static specHelper = new SpecHelper()
@@ -51,5 +56,6 @@ class UnirestWrapper extends Unirest {
             config().proxy(proxyHost, proxyPort.toInteger())
         }
         config().verifySsl(false)
+        config().cookieSpec(CookieSpecs.IGNORE_COOKIES)
     }
 }

--- a/src/test/groovy/org/ods/e2e/util/UnirestWrapper.groovy
+++ b/src/test/groovy/org/ods/e2e/util/UnirestWrapper.groovy
@@ -4,10 +4,6 @@ import kong.unirest.GetRequest
 import kong.unirest.HttpRequestWithBody
 import kong.unirest.Unirest
 import org.apache.http.client.config.CookieSpecs
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.impl.client.HttpClients
-
-import java.net.http.HttpClient
 
 class UnirestWrapper extends Unirest {
     def static specHelper = new SpecHelper()


### PR DESCRIPTION
Disable cookie check to avoid annoying messages in logs like:

`May 14, 2024 12:27:35 PM unirest.shaded.org.apache.http.client.protocol.ResponseProcessCookies processCookies
    WARNING: Invalid cookie header: "Set-Cookie: AWSALB=+zb357yqgB4iSRuvfaWGEfHpMeyGbte04+lsEK74njs5slauU1uNVqm+JZu1WwMaiydsff+l+AfXevrKIT5GYtl9sO+qjkeOEiljyIaYwoRV2Lm4JeHL01uXckvw; Expires=Tue, 21 May 2024 12:27:35 GMT; Path=/". Invalid 'expires' attribute: Tue, 21 May 2024 12:27:35 GMT`